### PR TITLE
Update smoke decision | smoke test is required for new pages.

### DIFF
--- a/adr/0024-smoke-tests-maintainance-required.md
+++ b/adr/0024-smoke-tests-maintainance-required.md
@@ -11,6 +11,7 @@ Smoke tests find UI problems and guard UI test architecture early in the develop
 ## Decision
 
 Covering all elements inside the smoke tests is required when new element is added or change is made.
+Adding smoke tests is required when new page is created.
 
 ## Consequences
 


### PR DESCRIPTION
When we first took this adr decision, we verbally said that it did not cover the newly added pages because there were too many pages missing.

Now since almost every page is covered by smoke tests it is easy to cover a new page with a generator.

